### PR TITLE
Update to bundle definition v4

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,28 +1,46 @@
 ---
-cog_bundle_version: 3
+cog_bundle_version: 4
 name: net
 description: "Simple network utilities"
-version: "0.1"
+author: "Operable <support@operable.io>"
+homepage: "https://github.com/cogcmd/net"
+version: "0.2"
 docker:
   image: "cogcmd/net"
-  tag: "0.1"
+  tag: "0.2"
 commands:
   dig:
     executable: "/bundle/dig.sh"
     description: "DNS lookup utility"
-    documentation: "dig [--short] [--trace] [--server server] <target>"
+    long_description: |
+      Simple wrapper for the `dig` command line utility. Only a select
+      few options are exposed in this command; it is not intended to
+      be a complete "dig in chat" tool.
+    arguments: "<target>"
     rules:
       - "when command is net:dig allow"
     options:
       short:
+        description: "Return a terse answer. Verbose reply is the default"
         type: bool
         required: false
       type:
+        description: "Valid BIND 9 query type. Defaults to 'A'"
         type: string
         required: false
       server:
+        description: "Name server to query"
         type: string
+        required: false
+      trace:
+        description: "Enable the 'trace' query option. Disabled by default"
+        type: bool
         required: false
 templates:
   dig:
-    slack: "```{{#body}}{{{.}}}\n{{/body}}```"
+    body: |
+      ~each var=$results~
+      ```~each var=$item.body as=l~
+      ~$l~
+      ~end~```
+      ~end~


### PR DESCRIPTION
- Update to structured documentation
- Use Greenbar templates
- Expose the `--trace` option, which was present in code, but not
  available to Cog.

![slack](https://cloud.githubusercontent.com/assets/207178/18517018/f2434c62-7a68-11e6-9732-a9f0ac381e71.png)
![slack](https://cloud.githubusercontent.com/assets/207178/18517033/fe35cfe0-7a68-11e6-88ea-d95c76cdab08.png)
![slack](https://cloud.githubusercontent.com/assets/207178/18517057/0d09a370-7a69-11e6-886d-3bfb1f02905a.png)
